### PR TITLE
Fix case conversion for all fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ $ openapi --help
     --postfixServices         Service name postfix (default: "Service")
     --postfixModels           Model name postfix
     --request <value>         Path to custom request file
+    --transformCase <value>   Transforms field names to specified case [camel, snake] (default: none)
     -h, --help                display help for command
 
   Examples

--- a/bin/index.js
+++ b/bin/index.js
@@ -24,7 +24,7 @@ const params = program
     .option('--postfix <value>', 'Deprecated: Use --postfixServices instead. Service name postfix', 'Service')
     .option('--postfixServices <value>', 'Service name postfix', 'Service')
     .option('--postfixModels <value>', 'Model name postfix')
-    .option('--transformModelCase <value>', 'Transform model case [camel, snake]', 'none')
+    .option('--transformCase <value>', 'Transforms field names to specified case [camel, snake]', 'none')
     .option('--request <value>', 'Path to custom request file')
     .parse(process.argv)
     .opts();
@@ -46,7 +46,7 @@ if (OpenAPI) {
         indent: params.indent,
         postfixServices: params.postfixServices ?? params.postfix,
         postfixModels: params.postfixModels,
-        transformModelCase: params.transformModelCase,
+        transformCase: params.transformCase,
         request: params.request,
     })
         .then(() => {

--- a/src/Case.ts
+++ b/src/Case.ts
@@ -1,3 +1,4 @@
+import { Enum } from './client/interfaces/Enum';
 import { Model } from './client/interfaces/Model';
 
 export enum Case {
@@ -23,16 +24,19 @@ const transforms = {
 // A recursive function that looks at the models and their properties and
 // converts each property name using the provided transform function.
 export const convertModelNames = (model: Model, type: Exclude<Case, Case.NONE>): Model => {
-    if (!model.properties.length) {
-        return {
-            ...model,
-            name: transforms[type](model.name),
-        };
-    }
     return {
         ...model,
-        properties: model.properties.map(property => {
-            return convertModelNames(property, type);
-        }),
+        name: transforms[type](model.name),
+        link: model.link ? convertModelNames(model.link, type) : null,
+        enum: model.enum.map(modelEnum => convertEnumName(modelEnum, type)),
+        enums: model.enums.map(property => convertModelNames(property, type)),
+        properties: model.properties.map(property => convertModelNames(property, type)),
+    };
+};
+
+const convertEnumName = (modelEnum: Enum, type: Exclude<Case, Case.NONE>): Enum => {
+    return {
+        ...modelEnum,
+        name: transforms[type](modelEnum.name),
     };
 };

--- a/src/Case.ts
+++ b/src/Case.ts
@@ -1,12 +1,14 @@
 import { Enum } from './client/interfaces/Enum';
 import { Model } from './client/interfaces/Model';
+import { OperationResponse } from './client/interfaces/OperationResponse';
+import { Service } from './client/interfaces/Service';
 
 export enum Case {
     NONE = 'none',
     CAMEL = 'camel',
     SNAKE = 'snake',
 }
-// Convert a string from snake case or pascal case to camel case.
+// Convert a string from snake case to camel case.
 const toCamelCase = (str: string): string => {
     return str.replace(/_([a-z])/g, match => match[1].toUpperCase());
 };
@@ -23,7 +25,7 @@ const transforms = {
 
 // A recursive function that looks at the models and their properties and
 // converts each property name using the provided transform function.
-export const convertModelNames = (model: Model, type: Exclude<Case, Case.NONE>): Model => {
+export const convertModelNames = <T extends Model | OperationResponse>(model: T, type: Exclude<Case, Case.NONE>): T => {
     return {
         ...model,
         name: transforms[type](model.name),
@@ -38,5 +40,15 @@ const convertEnumName = (modelEnum: Enum, type: Exclude<Case, Case.NONE>): Enum 
     return {
         ...modelEnum,
         name: transforms[type](modelEnum.name),
+    };
+};
+
+export const convertServiceCase = (service: Service, type: Exclude<Case, Case.NONE>): Service => {
+    return {
+        ...service,
+        operations: service.operations.map(op => ({
+            ...op,
+            results: op.results.map(results => convertModelNames(results, type)),
+        })),
     };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export type Options = {
     indent?: Indent;
     postfixServices?: string;
     postfixModels?: string;
-    transformModelCase?: Case;
+    transformCase?: Case;
     request?: string;
     write?: boolean;
 };
@@ -49,7 +49,7 @@ export type Options = {
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
- * @param transformModelCase Transform model case (camel, snake)
+ * @param transformCase Transform case (camel, snake)
  * @param request Path to custom request file
  * @param write Write the files to disk (true or false)
  */
@@ -67,7 +67,7 @@ export const generate = async ({
     indent = Indent.SPACE_4,
     postfixServices = 'Service',
     postfixModels = '',
-    transformModelCase = Case.NONE,
+    transformCase = Case.NONE,
     request,
     write = true,
 }: Options): Promise<void> => {
@@ -98,7 +98,7 @@ export const generate = async ({
                 indent,
                 postfixServices,
                 postfixModels,
-                transformModelCase,
+                transformCase,
                 clientName,
                 request
             );
@@ -123,7 +123,7 @@ export const generate = async ({
                 indent,
                 postfixServices,
                 postfixModels,
-                transformModelCase,
+                transformCase,
                 clientName,
                 request
             );

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -31,7 +31,7 @@ import { writeClientServices } from './writeClientServices';
  * @param indent Indentation options (4, 2 or tab)
  * @param postfixServices Service name postfix
  * @param postfixModels Model name postfix
- * @param transformModelCase Transform model case (camel, snake)
+ * @param transformCase Transform model case (camel, snake)
  * @param clientName Custom client class name
  * @param request Path to custom request file
  */
@@ -49,7 +49,7 @@ export const writeClient = async (
     indent: Indent,
     postfixServices: string,
     postfixModels: string,
-    transformModelCase: Case,
+    transformCase: Case,
     clientName?: string,
     request?: string
 ): Promise<void> => {
@@ -101,7 +101,7 @@ export const writeClient = async (
             httpClient,
             useUnionTypes,
             indent,
-            transformModelCase
+            transformCase
         );
     }
 

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -81,6 +81,7 @@ export const writeClient = async (
             useOptions,
             indent,
             postfixServices,
+            transformCase,
             clientName
         );
     }

--- a/src/utils/writeClientModels.ts
+++ b/src/utils/writeClientModels.ts
@@ -17,7 +17,7 @@ import type { Templates } from './registerHandlebarTemplates';
  * @param httpClient The selected httpClient (fetch, xhr, node or axios)
  * @param useUnionTypes Use union types instead of enums
  * @param indent Indentation options (4, 2 or tab)
- * @param transformModelCase Transform model case (camel, snake)
+ * @param transformCase Transform model case (camel, snake)
  */
 export const writeClientModels = async (
     models: Model[],
@@ -26,10 +26,10 @@ export const writeClientModels = async (
     httpClient: HttpClient,
     useUnionTypes: boolean,
     indent: Indent,
-    transformModelCase: Case
+    transformCase: Case
 ): Promise<void> => {
     for (const model of models) {
-        const newModel = transformModelCase === Case.NONE ? model : convertModelNames(model, transformModelCase);
+        const newModel = transformCase === Case.NONE ? model : convertModelNames(model, transformCase);
         const file = resolve(outputPath, `${model.name}.ts`);
         const templateResult = templates.exports.model({
             ...newModel,

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -1,5 +1,6 @@
 import { EOL } from 'os';
 
+import { Case } from '../Case';
 import type { Service } from '../client/interfaces/Service';
 import { HttpClient } from '../HttpClient';
 import { Indent } from '../Indent';
@@ -39,7 +40,17 @@ describe('writeClientServices', () => {
             },
         };
 
-        await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false, Indent.SPACE_4, 'Service');
+        await writeClientServices(
+            services,
+            templates,
+            '/',
+            HttpClient.FETCH,
+            false,
+            false,
+            Indent.SPACE_4,
+            'Service',
+            Case.NONE
+        );
 
         expect(writeFile).toBeCalledWith('/UserService.ts', `service${EOL}`);
     });

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path';
 
+import { Case, convertServiceCase } from '../Case';
 import type { Service } from '../client/interfaces/Service';
 import type { HttpClient } from '../HttpClient';
 import type { Indent } from '../Indent';
@@ -19,6 +20,7 @@ import type { Templates } from './registerHandlebarTemplates';
  * @param useOptions Use options or arguments functions
  * @param indent Indentation options (4, 2 or tab)
  * @param postfix Service name postfix
+ * @param transformCase Transform model case (camel, snake)
  * @param clientName Custom client class name
  */
 export const writeClientServices = async (
@@ -30,12 +32,14 @@ export const writeClientServices = async (
     useOptions: boolean,
     indent: Indent,
     postfix: string,
+    transformCase: Case,
     clientName?: string
 ): Promise<void> => {
     for (const service of services) {
+        const newService = transformCase === Case.NONE ? service : convertServiceCase(service, transformCase);
         const file = resolve(outputPath, `${service.name}${postfix}.ts`);
         const templateResult = templates.exports.service({
-            ...service,
+            ...newService,
             httpClient,
             useUnionTypes,
             useOptions,


### PR DESCRIPTION
I tested your solution on some swagger files and noticed that it was not converting names of linked/nested fields. For example, the name of Enums were only converted in the main type linking to an Enum in a namespace, but not in the namespace itself. Fields in a nested object were also not converted. See example below.

```typescript
export type MyTools = {
  toolResources?: { // Case transformed correctly
    tool_for_you?: string; // Not case transformed in nested objects
  };
  tool: Tools.handyTool; // Enum is case transformed here
};

export namespace Tools {
  export enum handy_tool { // But not case transformed here - leads to TS error
    HAMMER_TIME = 'HAMMER_TIME',
    SAW = 'SAW',
  }
}
```

This PR fixes this by converting the case of all fields containing a name.

And thanks a lot for starting the PR. This is a great addition to the library :)